### PR TITLE
Proper support for Kalix, akka-grpc, protoc-gen-validate.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organizationHomepage := Some(url("https://www.improving.com/"))
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 lazy val common: Project = project
-  .disablePlugins(KalixPlugin)
+  .configure(Config.Kalix.library)
   .in(file("common"))
   .configure(Kalix.library("common"))
 

--- a/common/src/main/protobuf/com/example/common/kalix_policy.proto
+++ b/common/src/main/protobuf/com/example/common/kalix_policy.proto
@@ -1,0 +1,14 @@
+// This is the default Access Control List (ACL) for all components of this Kalix Service
+syntax = "proto3";
+
+package com.ossum.amenities.account;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/common/src/main/protobuf/com/example/common/nothing.proto
+++ b/common/src/main/protobuf/com/example/common/nothing.proto
@@ -1,0 +1,17 @@
+// this file only exists to generate something kalixy
+// to thwart the this generation exception:
+// java.lang.IllegalArgumentException: Nothing to generate!
+//	at kalix.codegen.SourceGeneratorUtils$.mainPackageName(SourceGeneratorUtils.scala:75)
+
+syntax = "proto3";
+
+package com.ossum.amenities.account;
+
+import "kalix/annotations.proto";
+
+service Nothing {
+  option (kalix.service) = {
+    type : SERVICE_TYPE_ACTION;
+    component: "nothing";
+  };
+}

--- a/project/Config.scala
+++ b/project/Config.scala
@@ -1,0 +1,265 @@
+import akka.grpc.sbt.AkkaGrpcPlugin
+import akka.grpc.sbt.AkkaGrpcPlugin.autoImport.akkaGrpcCodeGeneratorSettings
+import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
+import com.typesafe.sbt.packager.docker.DockerPlugin
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.*
+import com.typesafe.sbt.SbtNativePackager.autoImport.maintainer
+import sbt.Keys.*
+import sbt.*
+import scoverage.ScoverageKeys.{coverageFailOnMinimum, *}
+import sbtdynver.DynVerPlugin.autoImport.dynverSeparator
+import sbtdynver.DynVerPlugin.autoImport.dynverVTagPrefix
+import wartremover.WartRemover.autoImport.*
+
+import scala.collection.immutable.Seq
+import kalix.sbt.KalixPlugin
+import protocbridge.Target
+import sbtbuildinfo.BuildInfoKey
+import sbtbuildinfo.BuildInfoKeys.buildInfoKeys
+import sbtbuildinfo.BuildInfoKeys.buildInfoObject
+import sbtbuildinfo.BuildInfoKeys.buildInfoOptions
+import sbtbuildinfo.BuildInfoKeys.buildInfoPackage
+import sbtbuildinfo.BuildInfoKeys.buildInfoUsePackageAsPath
+import sbtbuildinfo.BuildInfoOption.BuildTime
+import sbtbuildinfo.BuildInfoOption.ToJson
+import sbtbuildinfo.BuildInfoOption.ToMap
+import sbtbuildinfo.BuildInfoPlugin
+import sbtprotoc.ProtocPlugin.autoImport.PB
+import scalapb.GeneratorOption
+import scalapb.GeneratorOption.{FlatPackage, *}
+
+import java.util.Calendar
+
+object Config {
+  def withInfo(p: Project): Project = {
+    p.settings(
+      ThisBuild / maintainer := "reid@ossum.biz",
+      ThisBuild / organization := "com.ossum.amenities",
+      ThisBuild / organizationHomepage :=
+        Some(new URL("https://reactific.com/")),
+      ThisBuild / organizationName := "Ossum Inc.",
+      ThisBuild / startYear := Some(2019),
+      ThisBuild / licenses +=
+        (
+          "Apache-2.0",
+          new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        ),
+      ThisBuild / versionScheme := Option("early-semver"),
+      ThisBuild / dynverVTagPrefix := false,
+      run / fork := true,
+      run / envVars += ("HOST", "0.0.0.0"),
+      run / javaOptions ++= Seq("-Dlogback.configurationFile=logback-dev-mode.xml"),
+
+        // NEVER  SET  THIS: version := "0.1"
+      // IT IS HANDLED BY: sbt-dynver
+      ThisBuild / dynverSeparator := "-",
+    )
+  }
+
+  object Scala {
+
+    lazy val scala_2_options: Seq[String] =
+      Seq(
+        "-deprecation",
+        "-feature",
+        // "-new-syntax",
+        "-release:11",
+        "-unchecked",
+        "-Xlog-reflective-calls",
+        "-Xlint",
+        // "-explain",
+        // "-explain-types",
+        // "-Werror",
+      )
+
+    lazy val java_options: Seq[String] = Seq(
+      "-Xlint:unchecked",
+      "-Xlint:deprecation",
+      "-parameters" // for Jackson
+    )
+
+    def withScala2(p: Project): Project = {
+      p.configure(withInfo)
+        .settings(
+          scalaVersion := "2.13.10", // "3.3.1-RC7",
+          scalacOptions := scala_2_options,
+          apiURL := Some(url("https://riddl.tech/apidoc/")),
+          autoAPIMappings := true,
+          Test / parallelExecution := false,
+          Test / testOptions += Tests.Argument("-oDF"),
+          Test / logBuffered := false,
+          libraryDependencies ++= Dep.basicTestingDependencies ++ Dep.jsonDependencies
+      )
+    }
+
+    final val defaultPercentage: Int = 50
+
+    def withCoverage(percent: Int = defaultPercentage)(p: Project): Project = {
+      p.settings(
+        coverageFailOnMinimum := true,
+        coverageMinimumStmtTotal := percent,
+        coverageMinimumBranchTotal := percent,
+        coverageMinimumStmtPerPackage := percent,
+        coverageMinimumBranchPerPackage := percent,
+        coverageMinimumStmtPerFile := percent,
+        coverageMinimumBranchPerFile := percent,
+        coverageExcludedPackages := "<empty>"
+      )
+    }
+
+    def withBuildInfo(
+      homePage: String,
+      orgName: String,
+      packageName: String,
+      objName: String = "BuildInfo",
+      baseYear: Int = 2023
+    )(p: Project): Project = {
+      p.enablePlugins(BuildInfoPlugin)
+      .settings(
+        buildInfoObject := objName,
+        buildInfoPackage := packageName,
+        buildInfoOptions := Seq(ToMap, ToJson, BuildTime),
+        buildInfoUsePackageAsPath := true,
+        buildInfoKeys ++= Seq[BuildInfoKey](
+          name,
+          version,
+          description,
+          organization,
+          organizationName,
+          BuildInfoKey.map(organizationHomepage) { case (k, v) =>
+            k -> v.get.toString
+          },
+          BuildInfoKey.map(homepage) { case (k, v) =>
+            "projectHomepage" -> v.map(_.toString).getOrElse(homePage)
+          },
+          BuildInfoKey.map(startYear) { case (k, v) =>
+            k -> v.map(_.toString).getOrElse(baseYear.toString)
+          },
+          BuildInfoKey.map(startYear) { case (k, v) =>
+            "copyright" -> s"© ${v.map(_.toString).getOrElse(baseYear.toString)}-${
+              Calendar
+                .getInstance()
+                .get(Calendar.YEAR)
+            } $orgName}"
+          },
+          scalaVersion,
+          sbtVersion,
+          BuildInfoKey.map(scalaVersion) { case (k, v) =>
+            val version = if (v.head == '2') {
+              v.substring(0, v.lastIndexOf('.'))
+            }
+            else v
+            "scalaCompatVersion" -> version
+          },
+          BuildInfoKey.map(licenses) { case (k, v) =>
+            k -> v.map(_._1).mkString(", ")
+          }
+        )
+      )
+    }
+
+    def withWartRemover(proj: Project): Project = {
+      proj
+        .enablePlugins(wartremover.WartRemover)
+        .settings(
+          Compile / compile / wartremoverErrors ++= Warts.all,
+          // Compile / compile / wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.Serializable)
+          // wartremoverWarnings += Wart.Nothing,
+          // wartremoverWarnings ++= Seq(Wart.Any, Wart.Serializable)
+        )
+    }
+  }
+
+
+  def withDocker(proj: Project): Project = {
+    proj
+      .enablePlugins(DockerPlugin)
+      .settings(
+      dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot",
+      dockerUsername := sys.props.get("docker.username"),
+      dockerRepository := sys.props.get("docker.registry"),
+      dockerUpdateLatest := true,
+      dockerBuildCommand := {
+        val arch = sys.props("os.arch")
+        if (arch != "amd64" && !arch.contains("x86")) {
+          // use buildx with platform to build supported amd64 images on other CPU architectures
+          // this may require that you have first run 'docker buildx create' to set docker buildx up
+          dockerExecCommand.value ++ Seq(
+            "buildx",
+            "build",
+            "--platform=linux/amd64",
+            "--load"
+          ) ++ dockerBuildOptions.value :+ "."
+        } else dockerBuildCommand.value
+      }
+    )
+  }
+
+  object ScalaPB {
+
+    private val generator_options: Seq[GeneratorOption] = Seq(
+      FlatPackage,
+      SingleLineToProtoString,
+      RetainSourceCodeInfo
+    )
+
+    def protoGenValidate(project: Project): Project = {
+      project
+        .enablePlugins(AkkaGrpcPlugin)
+        .settings(
+          libraryDependencies += Dep.scalaPbValidateCore,
+          Compile / PB.targets ++= Seq[Target](
+            protocbridge.Target(
+              scalapb.validate.preprocessor(FlatPackage),
+              (Compile / akkaGrpcCodeGeneratorSettings / target).value
+            ),
+            protocbridge.Target(
+              scalapb.validate.gen(FlatPackage),
+              (Compile / akkaGrpcCodeGeneratorSettings / target).value)
+          )
+        )
+    }
+  }
+
+  val minCoverage: Int = 80
+
+  object Kalix {
+    def service(proj: Project): Project = {
+      proj.enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
+        .configure(Config.Scala.withCoverage(minCoverage))
+        .configure(Config.Scala.withScala2)
+        .configure(Config.ScalaPB.protoGenValidate)
+        .configure(Config.withDocker)
+        .settings(
+          // needed for the proxy to access the user function on all platforms
+          run / javaOptions ++= Seq(
+            "-Dkalix.user-function-interface=0.0.0.0",
+            "-Dlogback.configurationFile=logback-dev-mode.xml"
+          ),
+          run / fork := true,
+          Global / cancelable := false, // ctrl-c
+          libraryDependencies ++= Dep.testing ++ Dep.grpc ++ Dep.loggingDependencies
+        )
+    }
+
+    def library(proj: Project): Project = {
+      proj.enablePlugins(KalixPlugin, JavaAppPackaging)
+        .configure(Config.Scala.withScala2)
+        .configure(Config.Scala.withCoverage(minCoverage))
+        .configure(Config.ScalaPB.protoGenValidate)
+        .settings(
+          libraryDependencies ++= Dep.testing
+        )
+    }
+
+    def dependsOn(dependency: Project)(
+      project: Project
+    ): Project = {
+      project
+        .dependsOn(dependency)
+        .dependsOn( dependency % "protobuf")
+    }
+
+  }
+}
+

--- a/project/Dep.scala
+++ b/project/Dep.scala
@@ -1,0 +1,81 @@
+import kalix.sbt.KalixPlugin.KalixProtocolVersion
+import sbt.*
+
+/** V - Dependency Versions object */
+object V {
+  val circe = "0.14.5"
+  val commons_io = "20030203.000550"
+  val commons_codec = "20041127.091804"
+  val compress = "1.23.0"
+  val google_grpc = "2.24.0"
+  val kalixSDK = "1.3.2"
+  val jsoniterScala = "2.21.3"
+  val lang3 = "3.13.0"
+  val logback = "1.4.5"
+  val pureconfig = "0.17.4"
+  val scalapbCompiler = "0.11.13"
+  val scalacheck = "1.17.0"
+  val scalalogging = "3.9.5"
+  val scalamock = "5.2.0"
+  val scalatest = "3.2.16"
+  val scopt = "4.1.0"
+  val slf4j = "2.0.4"
+}
+
+object Dep {
+  lazy val commons_io = "commons-io" % "commons-io" % V.commons_io
+  lazy val google_grpc = "com.google.api.grpc" % "proto-google-common-protos" % V.google_grpc % "protobuf"
+
+  lazy val lang3 = "org.apache.commons" % "commons-lang3" % V.lang3
+  lazy val pureconfig = "com.github.pureconfig" %% "pureconfig-core" % V.pureconfig
+  lazy val scalactic = "org.scalactic" %% "scalactic" % V.scalatest % "test"
+  lazy val scalamock = "org.scalamock" %% "scalamock" % V.scalamock % Test
+  lazy val scalatest = "org.scalatest" %% "scalatest" % V.scalatest % "test"
+  lazy val scalacheck = "org.scalacheck" %% "scalacheck" % V.scalacheck % "test"
+  lazy val slf4j = "org.slf4j" % "slf4j-nop" % V.slf4j
+
+  lazy val grpc: Seq[ModuleID] = Seq(
+    google_grpc,
+    "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion,
+    "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+  )
+  lazy val commons_codec = "commons-codec" % "commons-codec" % V.commons_codec
+
+  lazy val testing: Seq[ModuleID] = Seq(scalactic, scalatest, scalacheck)
+
+  lazy val kalixScalaSdkProtobuf: ModuleID = "io.kalix" %% "kalix-scala-sdk-protobuf" % V.kalixSDK
+  lazy val kalixJvmCoreSdk: ModuleID = "io.kalix" %% "kalix-jvm-core-sdk" % V.kalixSDK % "protobuf"
+
+  lazy val kalixProto: Seq[ModuleID] = Seq(kalixScalaSdkProtobuf, kalixJvmCoreSdk)
+
+  lazy val scalaPbDependencies: Seq[ModuleID] = Seq(
+    "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
+    "io.kalix" % "kalix-sdk-protocol" % KalixProtocolVersion % "protobuf-src",
+    "com.google.protobuf" % "protobuf-java" % "3.22.2" % "protobuf"
+  )
+
+  val scalaPbCompilerPlugin: ModuleID = "com.thesamet.scalapb" %% "compilerplugin" % V.scalapbCompiler
+
+  val scalaPbValidateCore: ModuleID =
+    "com.thesamet.scalapb" %% "scalapb-validate-core" % scalapb.validate.compiler.BuildInfo.version % "protobuf"
+
+  val loggingDependencies: Seq[ModuleID] = Seq(
+    "ch.qos.logback" % "logback-classic" % V.logback,
+    "com.typesafe.scala-logging" %% "scala-logging" % V.scalalogging
+  )
+
+  val basicTestingDependencies: Seq[ModuleID] = Seq(
+    "org.scalatest" %% "scalatest" % V.scalatest % Test,
+    "org.scalamock" %% "scalamock" % V.scalamock % Test,
+    "org.scalacheck" %% "scalacheck" % V.scalacheck % "test"
+  )
+
+  val jsonDependencies: Seq[ModuleID] = Seq(
+    "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % V.jsoniterScala,
+    "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % V.jsoniterScala,
+    "io.circe" %% "circe-core" % V.circe,
+    "io.circe" %% "circe-generic" % V.circe,
+    "io.circe" %% "circe-parser" % V.circe
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,14 +6,19 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
-
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.11")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.4")
 
+// For ScalaPB 0.11.x:
 libraryDependencies ++= Seq(
-  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value,
   "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13",
   "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.4"
 )
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
+


### PR DESCRIPTION
This PR is useful but incomplete. It adds `project/Config` which provides the various configuration functions. Use it like:
`configure(Config.Kalix.library)` as was done for the common project to get it to work. 