### PR TITLE
Added a (local testing) CORS proxy for UI testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,10 @@ Make sure first to run the script `proto-gen`. Then use the command `npm start` 
    Don't worry, it is in the `.gitignore`, so your local changes will not be pushed up to the git server!
 2) Follow the instructions in `gateway/src/Test-Setup-Instructions.md`
 3) Profit!
+
+## Running the (local testing) CORS proxy
+
+Simply run this command:
+> sbt "gateway/test:runMain com.example.gateway.LocalCorsProxy"
+
+...after the Gateway and related services are started.

--- a/gateway/src/test/scala/com/example/gateway/LocalCorsProxy.scala
+++ b/gateway/src/test/scala/com/example/gateway/LocalCorsProxy.scala
@@ -1,0 +1,62 @@
+package com.example.gateway
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
+import akka.stream.scaladsl.Sink
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+object LocalCorsProxy {
+
+  def main(args: Array[String]): Unit = {
+    val proxyPort = args.view
+      .collectFirst { case arg if arg.startsWith("--port") => arg.split('=').drop(1).lastOption }
+      .flatten
+      .flatMap(portString => Try(portString.toInt).toOption)
+      .getOrElse(8010)  // default proxy port
+
+    val proxiedUri = Uri("http://localhost:9000")
+
+    val allowOriginHeader: HttpHeader = `Access-Control-Allow-Origin`.*
+
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val executionContext: ExecutionContext = system.dispatcher
+
+    val requestHandler: HttpRequest => Future[HttpResponse] =
+      request => {
+        val originalUri = request.uri
+        val proxyReqUri = proxiedUri
+          .withPath(originalUri.path)
+          .withRawQueryString(originalUri.rawQueryString.getOrElse(""))
+          .withFragment(originalUri.fragment.getOrElse(""))
+
+        println(s"Proxying request from '$originalUri' -> '$proxyReqUri'")
+
+        val corsRequest = request
+          .withUri(proxyReqUri)
+          .removeHeader("Timeout-Access")
+
+        Http().singleRequest(corsRequest).map { response =>
+          if (response.headers[`Access-Control-Allow-Origin`].isEmpty)
+            response
+              .removeHeader(`Access-Control-Allow-Origin`.name)
+              .addHeader(allowOriginHeader)
+          else
+            response
+        }
+      }
+
+    println(s"Starting proxy at `localhost` @ port: $proxyPort...")
+    val serverSource = Http().newServerAt("localhost", proxyPort).connectionSource()
+
+    serverSource.to(
+      Sink.foreach { connection =>
+        connection handleWithAsyncHandler requestHandler
+      }
+    ).run()
+  }
+
+}


### PR DESCRIPTION
To run the (local testing) CORS proxy, simply run:

> sbt "gateway/test:runMain com.example.gateway.LocalCorsProxy"

in a new shell/command window.